### PR TITLE
Add transport to client configuration

### DIFF
--- a/sensu/client.sls
+++ b/sensu/client.sls
@@ -5,6 +5,7 @@
 include:
   - sensu
   - sensu.rabbitmq_conf
+  - sensu.transport_conf
 
 {% if grains['os_family'] == 'Windows' %}
 /opt/sensu/bin/sensu-client.xml:


### PR DESCRIPTION
The changes from Luke did not cause the transport to be defined when the client is installed, which is our missing component.